### PR TITLE
Prefer version(Posix) when code is generic Unix.

### DIFF
--- a/src/med/display.d
+++ b/src/med/display.d
@@ -176,7 +176,7 @@ void vtinit()
     pscreen = new attchar_t[][term.t_nrow];
     vrowflags = new ubyte[term.t_nrow];
 
-    version (linux)
+    version (Posix)
     {
 	blnk_ln = new attchar_t[term.t_ncol];
     }
@@ -670,7 +670,7 @@ version (MOUSE)
         mpresf = FALSE;                 /* the message area. */
     }
 
-version (linux)
+version (Posix)
 {
     /* Here we check to see if we can scroll any of the lines.
      * This silly routine just checks for possibilites of scrolling
@@ -789,7 +789,7 @@ version (MOUSE)
  * row and column variables. It does try an exploit erase to end of line. The
  * RAINBOW version of this routine uses fast video.
  */
-version (linux)
+version (Posix)
 {
 void updateline(int row, attchar_t[] vline, attchar_t[] pline)
 {

--- a/src/med/fileio.d
+++ b/src/med/fileio.d
@@ -30,7 +30,7 @@ version (Windows)
     import core.sys.windows.windows;
 }
 
-version (linux)
+version (Posix)
 {
     import core.sys.posix.unistd;
     import core.sys.posix.sys.stat;
@@ -85,7 +85,7 @@ int ffrename(string from, string to)
     {
 	from = std.path.expandTilde(from);
 	to = std.path.expandTilde(to);
-	version (linux)
+	version (Posix)
 	{
 	    stat_t buf;
 	    if( stat( toStringz(from), &buf ) != -1
@@ -114,7 +114,7 @@ int ffrename(string from, string to)
  */
 int ffchmod(string subject, string image)
 {
-    version (linux)
+    version (Posix)
     {
 	subject = std.path.expandTilde(subject);
 	image = std.path.expandTilde(image);

--- a/src/med/more.d
+++ b/src/med/more.d
@@ -37,7 +37,7 @@ import display;
 import url;
 import utf;
 
-version (linux)
+version (Posix)
 {
     import core.sys.posix.signal;
     import core.sys.posix.unistd;
@@ -185,7 +185,7 @@ int Dignore(bool f, int n)
 
 int Dpause(bool f, int n)
 {
-    version (linux)
+    version (Posix)
     {
 	term.t_move( term.t_nrow - 1, 0 );
 	term.t_eeop();

--- a/src/med/spawn.d
+++ b/src/med/spawn.d
@@ -25,7 +25,7 @@ import std.process;
 import std.string;
 import std.utf;
 
-version(linux)
+version (Posix)
 {
     import core.sys.posix.unistd;
 }
@@ -58,7 +58,7 @@ int spawncli(bool f, int n)
 	args ~= "COMMAND.COM";
         spawnProcess(args);
     }
-    version (linux)
+    version (Posix)
     {
         term.t_flush();
         term.t_close();                             /* stty to old settings */
@@ -94,7 +94,7 @@ int spawn(bool f, int n)
         sgarbf = TRUE;
         return (TRUE);
     }
-    version (linux)
+    version (Posix)
     {
         if ((s=mlreply("! ", null, line)) != TRUE)
                 return (s);
@@ -162,7 +162,7 @@ version (Windows)
     if (std.file.exists(filnam) && std.file.isFile(filnam))
 	return FALSE;
 }
-version (linux)
+version (Posix)
 {
     term.t_putchar('\n');                /* Already have '\r'    */
     term.t_flush();
@@ -225,7 +225,7 @@ int spawn_filter(bool f, int n)
         movecursor(term.t_nrow - 2, 0);
         core.stdc.stdlib.system(toUTF8(line).toStringz());
     }
-    version (linux)
+    version (Posix)
     {
         term.t_putchar('\n');                /* Already have '\r'    */
         term.t_flush();

--- a/src/med/tcap.d
+++ b/src/med/tcap.d
@@ -391,7 +391,7 @@ static void build_long_keys(const(char)* term )
     lkroot.key = 0;
     lkroot.ptr = null;
 
-    version (linux)
+    version (Posix)
     {
         build_one_long("\033[A", UPKEY);
 	build_one_long("\033[B", DNKEY);

--- a/src/med/terminal.d
+++ b/src/med/terminal.d
@@ -14,7 +14,7 @@ version (Windows)
     public import mouse;
 }
 
-version (linux)
+version (Posix)
 {
     public import termio;
     public import xterm;


### PR DESCRIPTION
Hi Walter --

Nothing in med is Linux-specific. Using version(Linux) when nothing is Linux-specific needlessly locks out other operating systems from using D.

With this, med builds and runs on OpenBSD (and almost certainly macOS, and every other Posix system out there).

Thanks!